### PR TITLE
⬆ Update Bookstack to v21.04

### DIFF
--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -33,7 +33,7 @@ RUN \
         composer=2.0.11-r0 \
     \
     && curl -J -L -o /tmp/bookstack.tar.gz \
-        https://github.com/BookStackApp/BookStack/archive/v0.31.8.tar.gz \
+        https://github.com/BookStackApp/BookStack/archive/v21.04.tar.gz \
     &&  mkdir -p /var/www/bookstack \
     && tar zxvf /tmp/bookstack.tar.gz -C \
         /var/www/bookstack --strip-components=1 \


### PR DESCRIPTION
# Proposed Changes

⬆ Update Bookstack to v21.04

https://github.com/BookStackApp/BookStack/releases/tag/v21.04
