### PR TITLE
Update nginx.sh to remove if Statement

### DIFF
--- a/bookstack/rootfs/etc/cont-init.d/nginx.sh
+++ b/bookstack/rootfs/etc/cont-init.d/nginx.sh
@@ -4,6 +4,10 @@
 # This file configures nginx
 # ==============================================================================
 
+if bashio::var.is_empty "$(bashio::addon.port 80)"; then
+    bashio::log.warning "No host port is configured, please ensure a port is set for external access to function"
+fi
+
 bashio::config.require.ssl
 bashio::var.json \
     certfile "$(bashio::config 'certfile')" \

--- a/bookstack/rootfs/etc/cont-init.d/nginx.sh
+++ b/bookstack/rootfs/etc/cont-init.d/nginx.sh
@@ -4,13 +4,12 @@
 # This file configures nginx
 # ==============================================================================
 
-if bashio::var.has_value "$(bashio::addon.port 80)"; then
-    bashio::config.require.ssl
-    bashio::var.json \
-        certfile "$(bashio::config 'certfile')" \
-        keyfile "$(bashio::config 'keyfile')" \
-        ssl "^$(bashio::config 'ssl')" \
-        | tempio \
-            -template /etc/nginx/templates/direct.gtpl \
-            -out /etc/nginx/servers/direct.conf
-fi
+bashio::config.require.ssl
+bashio::var.json \
+    certfile "$(bashio::config 'certfile')" \
+    keyfile "$(bashio::config 'keyfile')" \
+    ssl "^$(bashio::config 'ssl')" \
+    | tempio \
+        -template /etc/nginx/templates/direct.gtpl \
+        -out /etc/nginx/servers/direct.conf
+


### PR DESCRIPTION
# Proposed Changes
Remove if statement on the nginx.sh script to allow nginx Config to include port 80 even if host port is not specified in the addon config. This will allow proxing from other services like NGINX to connect via internal docker network even if the host port is not specified.

I have confirmed that changes allow for internal docker network routing and host port is reachable if specified 