### PR TITLE
Remove NGINX access log from Supervisor log ouput

### DIFF
--- a/bookstack/rootfs/etc/nginx/nginx.conf
+++ b/bookstack/rootfs/etc/nginx/nginx.conf
@@ -24,11 +24,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Removes the access log from NGINX from the Supervisor add-on log output.
🧹  spring cleaning!
