### PR TITLE
⬆️ Upgrades BookStack to v21.04.3

### DIFF
--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -33,7 +33,7 @@ RUN \
         composer=2.0.13-r0 \
     \
     && curl -J -L -o /tmp/bookstack.tar.gz \
-        https://github.com/BookStackApp/BookStack/archive/v21.04.1.tar.gz \
+        https://github.com/BookStackApp/BookStack/archive/v21.04.3.tar.gz \
     &&  mkdir -p /var/www/bookstack \
     && tar zxvf /tmp/bookstack.tar.gz -C \
         /var/www/bookstack --strip-components=1 \


### PR DESCRIPTION
# Proposed Changes

Upgrades BookStack to v21.04.3

Release notes:
- v21.04.2: https://github.com/BookStackApp/BookStack/releases/tag/v21.04.2
- v21.04.3: https://github.com/BookStackApp/BookStack/releases/tag/v21.04.3