### PR TITLE
⬆ Update bookstack to v21.05

### DIFF
--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -32,7 +32,7 @@ RUN \
         composer=2.0.13-r0 \
     \
     && curl -J -L -o /tmp/bookstack.tar.gz \
-        https://github.com/BookStackApp/BookStack/archive/v21.04.3.tar.gz \
+        https://github.com/BookStackApp/BookStack/archive/v21.05.tar.gz \
     &&  mkdir -p /var/www/bookstack \
     && tar zxvf /tmp/bookstack.tar.gz -C \
         /var/www/bookstack --strip-components=1 \

--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -24,7 +24,6 @@ RUN \
         php7-pdo_mysql=7.4.19-r0 \
         php7-session=7.4.19-r0 \
         php7-simplexml=7.4.19-r0 \
-        php7-tidy=7.4.19-r0 \
         php7-tokenizer=7.4.19-r0 \
         php7-xml=7.4.19-r0 \
         php7=7.4.19-r0 \


### PR DESCRIPTION
# Proposed Changes


⬆ Update bookstack to v21.05
🔨 Remove php-tidy as no longer required

https://github.com/BookStackApp/BookStack/releases/tag/v21.05
