### PR TITLE
⬆ Update Bookstack to v21.08.3.

### DIFF
--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -32,7 +32,7 @@ RUN \
         composer=2.1.6-r0 \
     \
     && curl -J -L -o /tmp/bookstack.tar.gz \
-        https://github.com/BookStackApp/BookStack/archive/v21.05.4.tar.gz \
+        https://github.com/BookStackApp/BookStack/archive/v21.08.3.tar.gz \
     &&  mkdir -p /var/www/bookstack \
     && tar zxvf /tmp/bookstack.tar.gz -C \
         /var/www/bookstack --strip-components=1 \


### PR DESCRIPTION
# Proposed Changes

⬆ Update Bookstack to v21.08.3.

Release Notes:

https://github.com/BookStackApp/BookStack/releases/tag/v21.08.3
https://github.com/BookStackApp/BookStack/releases/tag/v21.08.2
https://github.com/BookStackApp/BookStack/releases/tag/v21.08.1
https://github.com/BookStackApp/BookStack/releases/tag/v21.08
