### PR TITLE
⬆️ Update Bookstack to v23.01.1

### DIFF
--- a/bookstack/Dockerfile
+++ b/bookstack/Dockerfile
@@ -32,7 +32,7 @@ RUN \
        composer=2.4.2-r0 \
     \
     && curl -J -L -o /tmp/bookstack.tar.gz \
-        https://github.com/BookStackApp/BookStack/archive/v22.11.tar.gz \
+        https://github.com/BookStackApp/BookStack/archive/v23.01.1.tar.gz \
     && mkdir -p /var/www/bookstack \
     && tar zxf /tmp/bookstack.tar.gz -C \
         /var/www/bookstack --strip-components=1 \


### PR DESCRIPTION
# Proposed Changes

> Updating Bookstack to v23.01.1 as this fixes a security issue in PDF generation
  I reviewed the last update commits and am still a bit unsure since I can't find a 'php artisan migrate' anywhere. Is the database not migrated on updates with this plugin?