### PR TITLE
Renovate: Use loose versioning for Bookstack

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,7 @@
         "ARG BOOKSTACK_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],
       "datasourceTemplate": "github-releases",
+      "versioningTemplate": "loose",
       "depNameTemplate": "BookStackApp/BookStack"
     }
   ],
@@ -52,12 +53,6 @@
     {
       "groupName": "Add-on base image",
       "matchDatasources": ["docker"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
-      "matchDatasources": ["github-releases"],
-      "matchDepNames": ["BookStackApp/BookStack"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }


### PR DESCRIPTION
# Proposed Changes

Bookstack uses some sort of datever, which doesn't have minor/major style (thus Renovate should not use its default semver).
