### PR TITLE
Fixed large upload sizes

### DIFF
--- a/bookstack/rootfs/etc/nginx/includes/server_params.conf
+++ b/bookstack/rootfs/etc/nginx/includes/server_params.conf
@@ -6,7 +6,7 @@ add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
-client_max_body_size 64M;
+client_max_body_size 4G;
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/bookstack/rootfs/etc/php81/php-fpm.d/www.conf
+++ b/bookstack/rootfs/etc/php81/php-fpm.d/www.conf
@@ -9,5 +9,5 @@ pm.min_spare_servers = 2
 pm.max_spare_servers = 5
 pm.max_requests = 1024
 clear_env = no
-php_admin_value[post_max_size] = 64M
-php_admin_value[upload_max_filesize] = 64M
+php_admin_value[post_max_size] = 4G
+php_admin_value[upload_max_filesize] = 4G


### PR DESCRIPTION
# Proposed Changes

Using the environment variable, FILE_UPLOAD_SIZE_LIMIT, the file upload size may be set to an arbitrary value.

This is supported in `/addon-bookstack/bookstack/rootfs/etc/nginx/nginx.conf` by `client_max_body_size 4G`.

However, this does not correctly override the nginx server limits and php limits of 64M respectively.

This changes the nginx server_params.conf and the php81 www.conf to 4G which mirrors the above.

Consider whether it is appropriate to set limits of 0 (i.e. unlimited). I didn't do this since it may cause other issues.

These changes confirmed working on my production instance by manually changing those files and restarting the nginx and php81 services.

## Related Issues

N/A
