### PR TITLE
Update max file size to 200M

### DIFF
--- a/bookstack/DOCS.md
+++ b/bookstack/DOCS.md
@@ -130,6 +130,7 @@ that there is no easy upgrade path between the two options.
 ## Known issues and limitations
 
 - Ingress will not function due to the way the application stores image files.
+- Uploading large images may result in PHP out of memory errors. This arises when PHP attempts to rescale the images and encounters an out of memory issue.
 
 ## Changelog & Releases
 

--- a/bookstack/rootfs/etc/nginx/includes/server_params.conf
+++ b/bookstack/rootfs/etc/nginx/includes/server_params.conf
@@ -6,7 +6,7 @@ add_header X-Content-Type-Options nosniff;
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Robots-Tag none;
 
-client_max_body_size 64M;
+client_max_body_size 200M;
 
 location / {
     try_files $uri $uri/ /index.php?$query_string;

--- a/bookstack/rootfs/etc/php83/php-fpm.d/www.conf
+++ b/bookstack/rootfs/etc/php83/php-fpm.d/www.conf
@@ -9,5 +9,5 @@ pm.min_spare_servers = 2
 pm.max_spare_servers = 5
 pm.max_requests = 1024
 clear_env = no
-php_admin_value[post_max_size] = 64M
-php_admin_value[upload_max_filesize] = 64M
+php_admin_value[post_max_size] = 200M
+php_admin_value[upload_max_filesize] = 200M


### PR DESCRIPTION
# Proposed Changes

> This increases the maximum upload file size to 200M.

## Related Issues

> A year ago now I PR'd an increase to the file limit in #280 
> Trying again with a more sane file limit of 200M.
> Not entirely sure how many people are using bookstack in the same way that I am but I upload all of the manuals for my appliances to bookstack and some of them exceed 100M in size.
> I do note that this is inconsistent with the 4G maximum file size configured in NGINX: https://github.com/illuzn/addon-bookstack/blob/86704a940f1c567c85fa63dabe4eaf74ac75e6bf/bookstack/rootfs/etc/nginx/nginx.conf#L28C5-L28C32
> This is the reason that I specified 4G previously. Although, it would make sense to reduce the NGINX value to a more sane 200M as an alternative.

> Note that issues #238 and https://github.com/BookStackApp/BookStack/issues/4306 are related.
> These issues document a potential PHP out of memory issue that arises when bookstack attempts to rescale large images.
> This issue can arise with a jpeg as small as 1.5MB (with a high level of compression) and, accordingly, is already affected by the existing maximum file size of 64M.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased maximum upload size for files from 64MB to 200MB.

- **Documentation**
  - Documented a known issue related to PHP out of memory errors during large image uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->