### PR TITLE
🔨 Update php memory limit to 256MB

### DIFF
--- a/bookstack/rootfs/etc/php83/php-fpm.d/www.conf
+++ b/bookstack/rootfs/etc/php83/php-fpm.d/www.conf
@@ -11,3 +11,4 @@ pm.max_requests = 1024
 clear_env = no
 php_admin_value[post_max_size] = 64M
 php_admin_value[upload_max_filesize] = 64M
+php_admin_value[memory_limit] = 256M


### PR DESCRIPTION
# Proposed Changes

🔨 Update php memory limit to 256MB

## Related Issues

Fixes #396 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased PHP memory limit to 256M for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->