### PR TITLE
fix warning: nginx 'listen ... http2' directive is deprecated

### DIFF
--- a/bookstack/rootfs/etc/nginx/templates/direct.gtpl
+++ b/bookstack/rootfs/etc/nginx/templates/direct.gtpl
@@ -2,7 +2,8 @@ server {
     {{ if not .ssl }}
     listen 80 default_server;
     {{ else }}
-    listen 80 default_server ssl http2;
+    listen 80 default_server ssl;
+    http2 on;
     {{ end }}
 
     include /etc/nginx/includes/server_params.conf;


### PR DESCRIPTION
# Proposed Changes

There's a warning in the logs
```
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/servers/direct.conf:3
```

It's fixed by using the parameter "http2 on;"
