### PR TITLE
🔨 Use bashio::app functions instead of the deprecated bashio::addon ones

### DIFF
--- a/bookstack/rootfs/etc/cont-init.d/bookstack.sh
+++ b/bookstack/rootfs/etc/cont-init.d/bookstack.sh
@@ -91,5 +91,5 @@ if bashio::config.has_value "appkey"; then
    bashio::log.info "Setting appkey to user defined value"
    key=$(bashio::config "appkey")
    echo "${key}" > /data/bookstack/appkey.txt
-   bashio::addon.option 'appkey'
+   bashio::app.option 'appkey'
 fi

--- a/bookstack/rootfs/etc/cont-init.d/nginx.sh
+++ b/bookstack/rootfs/etc/cont-init.d/nginx.sh
@@ -4,7 +4,7 @@
 # This file configures nginx
 # ==============================================================================
 
-if bashio::var.is_empty "$(bashio::addon.port 80)"; then
+if bashio::var.is_empty "$(bashio::app.port 80)"; then
     bashio::log.warning "No host port is configured, please ensure a port is"
     bashio::log.warning "set for external access to function"
 fi


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Bashio moved from v0.17.5 to v0.19.0 with base image 21.0.3. This adjusts the two call sites that the upgrade deprecated.

> [!NOTE]
> Stacked on #443, since #442 also edits `bookstack/rootfs/etc/cont-init.d/`. GitHub will retarget this automatically as the stack merges.

**What actually changed in bashio.** The add-on terminology was renamed to app in v0.18.0. `lib/apps.sh` now defines `bashio::app.*`, and every one of those functions gets a generated `bashio::addon.*` alias that delegates to the new name. The aliases still work, so nothing is broken today, but each one calls `bashio::apps.__deprecated` and logs `<old> is deprecated, use <new> instead.` the first time it is used. This repository hits two of them on every start:

- `bashio::addon.port` becomes `bashio::app.port` in `cont-init.d/nginx.sh`
- `bashio::addon.option` becomes `bashio::app.option` in `cont-init.d/bookstack.sh`

Those were the only deprecated calls. I checked every `bashio::` call in `rootfs/` against v0.19.0, and the other nineteen (`bashio::config*`, `bashio::services*`, `bashio::log*`, `bashio::fs.*`, `bashio::var.*`, `bashio::net.wait_for`, `bashio::exit.nok`) are all unchanged.

Verified by sourcing the bashio shipped in `ghcr.io/hassio-addons/base:21.0.3`: `bashio::app.port` and `bashio::app.option` are both defined, so the new names resolve against the image this app actually builds on. `shellcheck -s bash` is clean across all six scripts in `rootfs/`.

## The s6-overlay user bundles item needs nothing here

I could not reproduce the warning, and it turns out it is already fixed. Building this app and running the image on base 21.0.3, the init output is:

```
s6-rc-compile: warning: source /etc/s6-overlay/s6-rc.d is empty
```

with no mention of user bundles. Comparing the two base images explains why:

| | s6-overlay | user bundles live in |
| --- | --- | --- |
| `base:19.0.0` (before #433) | 3.2.1.0 | `/etc/s6-overlay/s6-rc.d/{user,user2}` |
| `base:21.0.3` (current) | 3.2.3.2 | `/etc/s6-overlay/user-bundles.d/{user,user2}` |

The base image already moved its bundles, so the deprecation warning disappeared with the base bump that merged in #433. This repository never defined bundles of its own; it uses the `/etc/services.d` and `/etc/cont-init.d` v2 compatibility layer, which is unaffected.

One thing worth passing upstream: `base:21.0.3` still ships an empty `/etc/s6-overlay/s6-rc.d`, which is what now produces `s6-rc-compile: warning: source /etc/s6-overlay/s6-rc.d is empty` on every start. That is a one-line fix in [`hassio-addons/addon-base`](https://github.com/hassio-addons/addon-base) (drop the empty directory), not something any individual app can address, and it would silence the warning across every app at once.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows the bashio upgrade that arrived with #433. Stacked on #443.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
