### PR TITLE
🐛 Mark the session cookie secure when serving TLS

### DIFF
--- a/bookstack/rootfs/etc/services.d/php-fpm/run
+++ b/bookstack/rootfs/etc/services.d/php-fpm/run
@@ -12,6 +12,20 @@ export DB_PORT
 export DB_USERNAME
 export LOG_CHANNEL=stderr
 
+# BookStack switches its session cookie to SameSite=None as soon as
+# ALLOWED_IFRAME_HOSTS is set, which is what embedding in a Home Assistant
+# dashboard requires. Browsers reject a SameSite=None cookie that is not also
+# marked Secure, leaving BookStack without a session, so logins bounce back to
+# the login page or fail with a 419. BookStack only infers Secure from APP_URL,
+# which this app does not set, so mark it explicitly when serving TLS.
+#
+# Only set when SSL is on. Leaving it unset otherwise keeps BookStack's own
+# APP_URL fallback working for anyone terminating TLS on a reverse proxy, and
+# setting it before the loop below means a user provided envvar still wins.
+if bashio::config.true 'ssl'; then
+    export SESSION_SECURE_COOKIE="true"
+fi
+
 for envvar in $(bashio::config 'envvars|keys'); do
     name=$(bashio::config "envvars[${envvar}].name")
     value=$(bashio::config "envvars[${envvar}].value")


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fixes the long-standing report in #399: setting `ALLOWED_IFRAME_HOSTS`, which is exactly what embedding Bookstack in a Home Assistant dashboard requires, makes it impossible to log in. The login form either bounces silently back to the login page or fails with `419 Page expired`, and removing the variable makes login work again but breaks the iframe.

**Root cause.** Three things line up badly:

1. `app/Http/Middleware/ApplyCspRules.php:30` sets `session.same_site` to `none` whenever any iframe host is configured.
2. Browsers reject a `SameSite=None` cookie that is not also flagged `Secure`. The session is never stored, so the login POST fails its CSRF check.
3. `app/Config/session.php:74` resolves `secure` as `env('SESSION_SECURE_COOKIE', null) ?? Str::startsWith(env('APP_URL', ''), 'https:')`. This app has always `export`ed `APP_URL` at `services.d/php-fpm/run:7` **without ever assigning it**, and never set `SESSION_SECURE_COOKIE`, so that expression was always `false`.

The result is a cookie every modern browser silently discards, regardless of whether the app itself is serving HTTPS.

**The fix.** Set `SESSION_SECURE_COOKIE=true` when the `ssl` option is on, before the `envvars` loop so a user supplied value still wins.

It is deliberately **not** set to `false` when `ssl` is off. An explicit `false` is not the same as leaving it unset: it short-circuits the `?? APP_URL` fallback, which would break anyone terminating TLS on a reverse proxy with `ssl: false` and `APP_URL=https://...` set by hand. That case works today and keeps working.

**Verification.** I resolved BookStack's real config inside the built image across the matrix that matters:

| # | `ALLOWED_IFRAME_HOSTS` | `SESSION_SECURE_COOKIE` | `APP_URL` | SameSite | Secure | |
|---|---|---|---|---|---|---|
| 1 | unset | unset | unset | `lax` | false | ok, default install unchanged |
| 2 | set | unset | unset | `none` | false | **the reported bug** |
| 3 | set | `true` | unset | `none` | true | **this fix** |
| 4 | set | unset | `https://…` | `none` | true | reverse proxy, still works |
| 5 | set | `false` | `https://…` | `none` | false | the variant I rejected, broken |

Row 2 reproduces #399 exactly, row 3 is what this PR produces with `ssl: true`, and rows 4 and 5 are why the flag is only ever set and never cleared.

`shellcheck -s bash` is clean across all six scripts in `rootfs/`.

**Scope note.** This does not add an `app_url` option or documentation, both of which are worth considering separately. Users behind a TLS terminating reverse proxy still need to set `APP_URL` themselves, and users on plain HTTP still cannot embed in an iframe at all, since a `Secure` cookie cannot be used over HTTP. That is a browser rule, not something this app can work around, and it is the actual answer to #438.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #399. Explains the failure reported in #438.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
